### PR TITLE
Update utils.py

### DIFF
--- a/custom_components/aqara_gateway/core/utils.py
+++ b/custom_components/aqara_gateway/core/utils.py
@@ -690,6 +690,7 @@ DEVICES = [{
     ]
 }, {
     'lumi.airrtc.tcpecn01': ["Aqara", "Thermostat S1", "KTWKQ02ES"],
+    'lumi.ctrl_hvac.es1': ["Aqara", "Thermostat", "KTWKQ01ES"],
     # https://github.com/AlexxIT/XiaomiGateway3/issues/101
     'lumi.airrtc.tcpecn02': ["Aqara", "Thermostat S2", "KTWKQ03ES"],
     'params': [


### PR DESCRIPTION
Add Aqara thermostat old model support. KTWKQ01ES, lumi.ctrl_hvac.es1.
Known Issue: Target temperature won't work until turn on the AC.