### PR TITLE
send 'position' instead of 'motor' when open or close cover

### DIFF
--- a/custom_components/aqara_gateway/core/utils.py
+++ b/custom_components/aqara_gateway/core/utils.py
@@ -1043,6 +1043,7 @@ DEVICES_AIOT = [{
     'params': [
         ['0.1.85', None, 'working_time', None],
         ['1.1.85', 'curtain_level', 'position', None],
+        ['0.55.85', None, 'position', None],
         ['4.1.85', None, 'motor_stroke', None],
         ['4.2.85', None, 'polarity', None],
         ['13.1.85', None, 'charging_status', None],

--- a/custom_components/aqara_gateway/cover.py
+++ b/custom_components/aqara_gateway/cover.py
@@ -136,11 +136,11 @@ class XiaomiGenericCover(GatewayGenericDevice, CoverEntity):
 
     def close_cover(self, **kwargs):
         """Close the cover."""
-        self.gateway.send(self.device, {'motor': 0})
+        self.gateway.send(self.device, {'position': 0})
 
     def open_cover(self, **kwargs):
         """Open the cover."""
-        self.gateway.send(self.device, {'motor': 1})
+        self.gateway.send(self.device, {'position': 100})
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""


### PR DESCRIPTION
Hello, when I using my Aqara Curtain Driver E1 (lumi.curtain.acn003), I found it would open when I click the 'close' button in HA. 
It maybe because its polarity has been changed, so I try to reverse the polarity again, it becomes correct.
and I checked the logs, but did not find any information about 'polarity' in the heartbeat, so checking polarity to use different motor seems impossible.

Then I try to control it in Aqara Home app, I found that aqara uses 'position' to open or close it.

Here is the logs
```
# close
2023-01-13 21:50:01 : MQTT on_message: zigbee/recv {"cmd":"write","did":"lumi.54ef44100050d4f7","id":567,"params":[{"res_name":"1.1.85","value":0}]}
2023-01-13 21:50:01 : MQTT on_message: zigbee/send {"cmd":"write_rsp","id":567,"time":1673617801379,"did":"lumi.54ef44100050d4f7","zseq":254,"results":[{"res_name":"1.1.85","value":0,"error_code":0}]}
2023-01-13 21:50:01 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'position': 0} [1673617801.4951725]
2023-01-13 21:50:01 : MQTT on_message: zigbee/send {"cmd":"write_ack","id":567,"did":"lumi.54ef44100050d4f7","dev_src":"0","time":1673617801602,"rssi":-62,"zseq":255,"params":[{"res_name":"1.1.85","value":0}]}
2023-01-13 21:50:01 : MQTT on_message: zigbee/send {"cmd":"report","id":567,"did":"lumi.54ef44100050d4f7","time":1673617801714,"rssi":-46,"zseq":173,"params":[{"res_name":"1.1.85","value":0}],"dev_src":"0"}
2023-01-13 21:50:01 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'position': 0} [1673617801.832239]
2023-01-13 21:50:02 : MQTT on_message: zigbee/send {"cmd":"report","id":2000137120,"did":"lumi.54ef44100050d4f7","time":1673617802681,"rssi":-51,"zseq":174,"params":[{"res_name":"14.4.85","value":0}],"dev_src":"0"}
2023-01-13 21:50:02 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'run_state': 0} [1673617802.8007436]
2023-01-13 21:50:18 : MQTT on_message: zigbee/send {"cmd":"report","id":2000137125,"did":"lumi.54ef44100050d4f7","time":1673617818798,"rssi":-43,"zseq":175,"params":[{"res_name":"14.4.85","value":2}],"dev_src":"0"}
2023-01-13 21:50:18 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'run_state': 2} [1673617818.9269893]
2023-01-13 21:50:18 : MQTT on_message: zigbee/send {"cmd":"report","id":2000137126,"did":"lumi.54ef44100050d4f7","time":1673617818816,"rssi":-43,"zseq":176,"params":[{"res_name":"0.55.85","value":0}],"dev_src":"0"}
2023-01-13 21:50:18 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'position': 0} [1673617818.9352176]

# open
2023-01-13 21:51:33 : MQTT on_message: zigbee/recv {"cmd":"write","did":"lumi.54ef44100050d4f7","id":568,"params":[{"res_name":"1.1.85","value":100}]}
2023-01-13 21:51:33 : MQTT on_message: zigbee/send {"cmd":"write_rsp","id":568,"time":1673617893240,"did":"lumi.54ef44100050d4f7","zseq":176,"results":[{"res_name":"1.1.85","value":100,"error_code":0}]}
2023-01-13 21:51:33 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'position': 100} [1673617893.3591337]
2023-01-13 21:51:33 : MQTT on_message: zigbee/send {"cmd":"write_ack","id":568,"did":"lumi.54ef44100050d4f7","dev_src":"0","time":1673617893536,"rssi":-47,"zseq":0,"params":[{"res_name":"1.1.85","value":100}]}
2023-01-13 21:51:33 : MQTT on_message: zigbee/send {"cmd":"report","id":568,"did":"lumi.54ef44100050d4f7","time":1673617893653,"rssi":-47,"zseq":177,"params":[{"res_name":"1.1.85","value":100}],"dev_src":"0"}
2023-01-13 21:51:33 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'position': 100} [1673617893.7713463]
2023-01-13 21:51:34 : MQTT on_message: zigbee/send {"cmd":"report","id":2000137151,"did":"lumi.54ef44100050d4f7","time":1673617894626,"rssi":-46,"zseq":178,"params":[{"res_name":"14.4.85","value":1}],"dev_src":"0"}
2023-01-13 21:51:34 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'run_state': 1} [1673617894.7453034]

# stop
2023-01-13 21:51:40 : MQTT on_message: zigbee/recv {"cmd":"write","did":"lumi.54ef44100050d4f7","id":569,"params":[{"res_name":"14.8.85","value":2}]}
2023-01-13 21:51:40 : MQTT on_message: zigbee/send {"cmd":"write_rsp","id":569,"time":1673617900119,"did":"lumi.54ef44100050d4f7","zseq":178,"results":[{"res_name":"14.8.85","value":2,"error_code":0}]}
2023-01-13 21:51:40 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'motor': 2} [1673617900.2384734]
2023-01-13 21:51:40 : MQTT on_message: zigbee/send {"cmd":"report","id":569,"did":"lumi.54ef44100050d4f7","time":1673617900691,"rssi":-50,"zseq":179,"params":[{"res_name":"14.8.85","value":2}],"dev_src":"0"}
2023-01-13 21:51:40 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'motor': 2} [1673617900.8112285]
2023-01-13 21:51:41 : MQTT on_message: zigbee/send {"cmd":"report","id":2000137153,"did":"lumi.54ef44100050d4f7","time":1673617901708,"rssi":-50,"zseq":180,"params":[{"res_name":"14.4.85","value":2}],"dev_src":"0"}
2023-01-13 21:51:41 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'run_state': 2} [1673617901.838652]
2023-01-13 21:51:41 : MQTT on_message: zigbee/send {"cmd":"report","id":568,"did":"lumi.54ef44100050d4f7","time":1673617901726,"rssi":-48,"zseq":181,"params":[{"res_name":"1.1.85","value":44}],"dev_src":"0"}
2023-01-13 21:51:41 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'position': 44} [1673617901.8458858]
2023-01-13 21:51:41 : MQTT on_message: zigbee/send {"cmd":"report","id":2000137154,"did":"lumi.54ef44100050d4f7","time":1673617901730,"rssi":-50,"zseq":182,"params":[{"res_name":"0.55.85","value":44}],"dev_src":"0"}
2023-01-13 21:51:41 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'position': 44} [1673617901.8554463]
2023-01-13 21:51:43 : MQTT on_message: zigbee/send {"cmd":"report","id":568,"did":"lumi.54ef44100050d4f7","time":1673617903883,"rssi":-50,"zseq":183,"params":[{"res_name":"1.1.85","value":43}],"dev_src":"0"}
2023-01-13 21:51:44 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'position': 43} [1673617904.0003188]
2023-01-13 21:51:44 : MQTT on_message: zigbee/send {"cmd":"report","id":2000137155,"did":"lumi.54ef44100050d4f7","time":1673617903890,"rssi":-50,"zseq":184,"params":[{"res_name":"0.55.85","value":43}],"dev_src":"0"}
2023-01-13 21:51:44 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'position': 43} [1673617904.035292]

# change polarity when closed (position is 0), it would reset the position to 100
2023-01-13 21:56:36 : MQTT on_message: zigbee/recv {"cmd":"write","did":"lumi.54ef44100050d4f7","id":577,"params":[{"res_name":"4.71.85","value":1}]}
2023-01-13 21:56:36 : MQTT on_message: zigbee/send {"cmd":"write_rsp","id":577,"time":1673618196199,"did":"lumi.54ef44100050d4f7","zseq":8,"results":[{"res_name":"4.71.85","value":1,"error_code":0}]}
2023-01-13 21:56:36 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'4.71.85': 1} [1673618196.3254514]
2023-01-13 21:56:37 : MQTT on_message: zigbee/send {"cmd":"write_ack","id":577,"did":"lumi.54ef44100050d4f7","dev_src":"0","time":1673618196909,"rssi":-68,"zseq":9,"params":[{"res_name":"4.71.85","value":1}]}
2023-01-13 21:56:37 : MQTT on_message: zigbee/send {"cmd":"report","id":577,"did":"lumi.54ef44100050d4f7","time":1673618197016,"rssi":-41,"zseq":192,"params":[{"res_name":"4.71.85","value":1}],"dev_src":"0"}
2023-01-13 21:56:37 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'4.71.85': 1} [1673618197.1420364]
2023-01-13 21:56:37 : MQTT on_message: zigbee/send {"cmd":"report","id":2000137249,"did":"lumi.54ef44100050d4f7","time":1673618197737,"rssi":-41,"zseq":194,"params":[{"res_name":"1.1.85","value":100}],"dev_src":"0"}
2023-01-13 21:56:37 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'position': 100} [1673618197.86324]
2023-01-13 21:56:37 : MQTT on_message: zigbee/send {"cmd":"report","id":2000137250,"did":"lumi.54ef44100050d4f7","time":1673618197742,"rssi":-41,"zseq":195,"params":[{"res_name":"0.55.85","value":100}],"dev_src":"0"}
2023-01-13 21:56:37 : lumi.54ef44100050d4f7 lumi.curtain.acn003 <= {'position': 100} [1673618197.8736844]
```

So I try to send 'position' instead of 'motor' when open or close cover, It works fine on all my devices:

- Curtain Driver E1 (lumi.curtain.acn003)
- Curtain C2 (lumi.curtain.hagl07)
- Roller Shade E1 (lumi.curtain.acn002)
- Smart Vertical Blinds Controller H1 (lumi.curtain.acn011) ZNMHLDJ01LM


in addition, I rechecked the logs when open or close them with Aqara Home, the above three are send the 'position' and the bottom one is send the 'motor' (but when open it sends motor:0 and close is 1, not sure if depends on polarity)