### PR TITLE
Roller Shade and Light fixes

### DIFF
--- a/custom_components/aqara_gateway/core/utils.py
+++ b/custom_components/aqara_gateway/core/utils.py
@@ -335,8 +335,8 @@ DEVICES = [{
         ['4.1.85', 'power_status', 'light', 'light'],
         ['14.1.85', 'light_level', 'brightness', None],
         ['14.2.85', 'colour_temperature', 'color_temp', None],
-        ['14.5.85', 'rgb_color', 'rgb_color', None],
-        ['14.46.85', None, 'dual_color_temperature_mode', None],
+        ['14.8.85', 'xy_color', 'xy_color', None],
+        ['14.11.85', None, 'dual_color_temperature_mode', None],
         ['8.0.2022', None, 'ambilight', None],
         ['8.0.2150', None, 'dynamic', None],
     ]

--- a/custom_components/aqara_gateway/cover.py
+++ b/custom_components/aqara_gateway/cover.py
@@ -77,6 +77,7 @@ class XiaomiGenericCover(GatewayGenericDevice, CoverEntity):
         self._motor_stroke = None
         self._charging_status = None
         self._working_time = None
+        self._model = device['model']
         if device['model'] == 'lumi.curtain.acn002':
             self._attr_current_cover_tilt_position = 0
         if device['model'] in DEVICES_WITH_BATTERY:
@@ -128,11 +129,12 @@ class XiaomiGenericCover(GatewayGenericDevice, CoverEntity):
                 self._working_time = value
             if key == POSITION:
                 self._pos = value
-                if device['model'] not in DEVICES_WITH_NO_TILT:
-                    if hasattr(self, "current_cover_tilt_position"):
-                        self._attr_current_cover_tilt_position = value
+                if hasattr(self, "current_cover_tilt_position") and self._model not in DEVICES_WITH_NO_TILT:
+                    self._attr_current_cover_tilt_position = value
             if key == RUN_STATE:
                 self._state = RUN_STATES.get(value, STATE_UNKNOWN)
+
+
 
         self.schedule_update_ha_state()
 

--- a/custom_components/aqara_gateway/cover.py
+++ b/custom_components/aqara_gateway/cover.py
@@ -43,6 +43,7 @@ CHARGING_STATUS_ = {0: "Not Charging", 1: "Charging", 2: "Stop Charging", 3: "Ch
 MOTOR_STROKES = {0: "No stroke", 1: "The stroke has been set"}
 
 DEVICES_WITH_BATTERY = ['lumi.curtain.acn002', 'lumi.curtain.acn003', 'lumi.curtain.agl001']
+DEVICES_WITH_NO_TILT = ['lumi.curtain.vagl02', 'lumi.curtain.aq2']
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Perform the setup for Xiaomi devices."""
@@ -127,8 +128,9 @@ class XiaomiGenericCover(GatewayGenericDevice, CoverEntity):
                 self._working_time = value
             if key == POSITION:
                 self._pos = value
-                if hasattr(self, "current_cover_tilt_position"):
-                    self._attr_current_cover_tilt_position = value
+                if device['model'] not in DEVICES_WITH_NO_TILT:
+                    if hasattr(self, "current_cover_tilt_position"):
+                        self._attr_current_cover_tilt_position = value
             if key == RUN_STATE:
                 self._state = RUN_STATES.get(value, STATE_UNKNOWN)
 

--- a/custom_components/aqara_gateway/light.py
+++ b/custom_components/aqara_gateway/light.py
@@ -58,13 +58,6 @@ class GatewayLight(GatewayGenericDevice, LightEntity):
         self._fw_ver = None
         self._hw_ver = None
         self._lqi = None
-        for parm in device['params']:
-            if parm[2] == "brightness":
-                self._attr_supported_features |= SUPPORT_BRIGHTNESS
-            if parm[2] == "color_temp":
-                self._attr_supported_features |= SUPPORT_COLOR_TEMP
-            if parm[2] == "rgb_color":
-                self._attr_supported_features |= SUPPORT_COLOR
         if self.device['type'] == 'gateway':
             self._attr_supported_features = SUPPORT_COLOR | SUPPORT_BRIGHTNESS
 
@@ -101,13 +94,18 @@ class GatewayLight(GatewayGenericDevice, LightEntity):
                     self._state = any(data[self._attr])
                 else:
                     self._state = data[self._attr] >= 1
+
             if ATTR_BRIGHTNESS in data:
+                self._attr_supported_features |= SUPPORT_BRIGHTNESS
                 self._attr_brightness = int(data[ATTR_BRIGHTNESS] / 100.0 * 255.0)
             if ATTR_COLOR_TEMP in data:
+                self._attr_supported_features |= SUPPORT_COLOR_TEMP
                 self._attr_color_temp = data[ATTR_COLOR_TEMP]
             if ATTR_RGB_COLOR in data:
+                self._attr_supported_features |= SUPPORT_COLOR
                 self._attr_rgb_color = data[ATTR_RGB_COLOR]
             if ATTR_HS_COLOR in data:
+                self._attr_supported_features |= SUPPORT_COLOR
                 if self.device['type'] == 'zigbee':
                     if isinstance(data[ATTR_HS_COLOR], int):
                         value = hex(data[ATTR_HS_COLOR] & 0xFFFFFF).replace('0x', '')


### PR DESCRIPTION
- Roller Shades should not have a tilt position (excluded the devices I tested)
- Fixed issue with LED Dimmer in dual color temperature mode (was showing color picker in HA and when used, light stopped working)
- Updated `self._attr_supported_features` for light to be set based on data coming from the device, not based on device params definition

** xy color support missing, to be implemented later