### PR TITLE
fix params of lumi.switch.rkna01

### DIFF
--- a/custom_components/aqara_gateway/core/utils.py
+++ b/custom_components/aqara_gateway/core/utils.py
@@ -747,6 +747,7 @@ DEVICES = [{
     'params': [
         ['0.12.85', 'load_power', 'power', 'sensor'],
         ['0.13.85', None, 'consumption', 'sensor'],
+        ['13.1.85', None, 'button', None],
         ['0.24.85', 'rotate_angle', 'rotate_angle', None],
         ['0.25.85', 'action_duration', 'action_time', None],
         ['0.29.85', 'rotate_angle', 'rotate_angle', None],  # while hold
@@ -756,7 +757,6 @@ DEVICES = [{
         ['4.2.85', 'channel_1', 'channel 2', 'switch'],
         ['4.3.85', 'channel_2', 'channel 3', 'switch'],
         [None, None, 'switch', 'binary_sensor'],
-        ['8.0.2001', 'battery', 'battery', 'sensor'],
         ['13.8.85', None, 'mode', None],
         ['14.6.85', None, 'sensitivity', None],
         ['14.7.85', 'single_click_control_mode', 'mode', None],


### PR DESCRIPTION
- remove the battery.  It's a device with neutral wire, no battery.

- add params for button action.

Here is logs
```
# single
2023-03-07 20:40:27  ...  lumi.4cf8cdf3c8c9245 lumi.switch.rkna01 <= {'13.1.85': 1} [1678192827.3951564]
# double
2023-03-07 20:40:44  ...  lumi.4cf8cdf3c8c9245 lumi.switch.rkna01 <= {'13.1.85': 2} [1678192844.8980699]
# hold
2023-03-07 20:40:52  ...  lumi.4cf8cdf3c8c9245 lumi.switch.rkna01 <= {'13.1.85': 16} [1678192852.9913633]
# release
2023-03-07 20:40:54  ...  lumi.4cf8cdf3c8c9245 lumi.switch.rkna01 <= {'13.1.85': 17} [1678192854.2477348]
```