### PR TITLE
Fix warning in HA 2024.1 (HA>=2022.11)

### DIFF
--- a/custom_components/aqara_gateway/alarm_control_panel.py
+++ b/custom_components/aqara_gateway/alarm_control_panel.py
@@ -1,17 +1,14 @@
 """ Aqara Gateway Alarm Control Panel """
 
 from homeassistant.components.alarm_control_panel import (
-    SUPPORT_ALARM_ARM_AWAY,
-    SUPPORT_ALARM_ARM_HOME,
-    SUPPORT_ALARM_ARM_NIGHT,
     AlarmControlPanelEntity,
+    AlarmControlPanelEntityFeature,
 )
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_DISARMED,
-    STATE_ALARM_ARMING,
 )
 
 from . import DOMAIN, GatewayGenericDevice
@@ -62,8 +59,8 @@ class AqaraGatewayAlarm(GatewayGenericDevice, AlarmControlPanelEntity):
         self._shell.login()
         self._get_state()
         super().__init__(gateway, device, attr)
-        self._attr_supported_features = (SUPPORT_ALARM_ARM_HOME |
-                SUPPORT_ALARM_ARM_AWAY | SUPPORT_ALARM_ARM_NIGHT)
+        self._attr_supported_features = (AlarmControlPanelEntityFeature.ARM_HOME |
+                AlarmControlPanelEntityFeature.ARM_AWAY | AlarmControlPanelEntityFeature.ARM_NIGHT)
 
     @property
     def should_poll(self):
@@ -85,8 +82,8 @@ class AqaraGatewayAlarm(GatewayGenericDevice, AlarmControlPanelEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return (SUPPORT_ALARM_ARM_HOME | SUPPORT_ALARM_ARM_AWAY |
-                SUPPORT_ALARM_ARM_NIGHT)
+        return (AlarmControlPanelEntityFeature.ARM_HOME | AlarmControlPanelEntityFeature.ARM_AWAY |
+                AlarmControlPanelEntityFeature.ARM_NIGHT)
 
     @property
     def code_arm_required(self):

--- a/custom_components/aqara_gateway/binary_sensor.py
+++ b/custom_components/aqara_gateway/binary_sensor.py
@@ -4,11 +4,9 @@ import time
 from homeassistant.components.automation import ATTR_LAST_TRIGGERED
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
-    DEVICE_CLASS_DOOR,
-    DEVICE_CLASS_MOISTURE
+    BinarySensorDeviceClass,
 )
 from homeassistant.config import DATA_CUSTOMIZE
-from homeassistant.core import callback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util.dt import now
 from homeassistant.const import (
@@ -45,8 +43,8 @@ from .core.const import (
 
 
 DEVICE_CLASS = {
-    'contact': DEVICE_CLASS_DOOR,
-    'water_leak': DEVICE_CLASS_MOISTURE,
+    'contact': BinarySensorDeviceClass.DOOR,
+    'water_leak': BinarySensorDeviceClass.MOISTURE,
 }
 
 

--- a/custom_components/aqara_gateway/climate.py
+++ b/custom_components/aqara_gateway/climate.py
@@ -1,18 +1,11 @@
 """Support for Xiaomi Aqara Climate."""
 import logging
-from typing import Optional
 
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, TEMP_CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
-    SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_FAN_MODE,
-    SUPPORT_SWING_MODE,
+    HVACMode,
+    ClimateEntityFeature,
     SWING_OFF,
     SWING_ON
 )
@@ -77,17 +70,17 @@ class AqaraGenericClimate(GatewayGenericDevice, ClimateEntity):
     @property
     def temperature_unit(self):
         """ return temperature uint """
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def hvac_mode(self) -> str:
         """ return hvac mode """
-        return self._hvac_mode if self._is_on else HVAC_MODE_OFF
+        return self._hvac_mode if self._is_on else HVACMode.OFF
 
     @property
     def hvac_modes(self):
         """ return hvac modes """
-        return [HVAC_MODE_OFF, HVAC_MODE_COOL, HVAC_MODE_HEAT]
+        return [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT]
 
     @property
     def current_temperature(self):
@@ -112,7 +105,7 @@ class AqaraGenericClimate(GatewayGenericDevice, ClimateEntity):
     @property
     def supported_features(self):
         """ return supported features """
-        return SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
+        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
 
     def update(self, data: dict = None):
         # pylint: disable=broad-except
@@ -196,12 +189,12 @@ class AqaraClimateYuba(AqaraGenericClimate, ClimateEntity):
     @property
     def hvac_modes(self):
         """ return hvac modes """
-        return [HVAC_MODE_OFF, HVAC_MODE_DRY, HVAC_MODE_HEAT, HVAC_MODE_AUTO]
+        return [HVACMode.OFF, HVACMode.DRY, HVACMode.HEAT, HVACMode.AUTO]
 
     @property
     def supported_features(self):
         """ return supported features """
-        return SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE
+        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.SWING_MODE
 
     @property
     def swing_mode(self) -> str | None:

--- a/custom_components/aqara_gateway/core/const.py
+++ b/custom_components/aqara_gateway/core/const.py
@@ -1,54 +1,30 @@
 """Constants of the Xiaomi Aqara component."""
 
 from homeassistant.const import (
-    # ATTR_BATTERY_LEVEL,
-    # ATTR_TEMPERATURE,
     CONDUCTIVITY,
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_PRESSURE,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_CO2,
-    DEVICE_CLASS_PM25,
-    DEVICE_CLASS_PM10,
-    DEVICE_CLASS_PM1,
-    ENERGY_WATT_HOUR,
-    ENERGY_KILO_WATT_HOUR,
     LIGHT_LUX,
     PERCENTAGE,
-    POWER_WATT,
-    PRESSURE_HPA,
-    TEMP_CELSIUS,
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
     STATE_OPEN,
     STATE_OPENING,
-    # STATE_CLOSED,
     STATE_CLOSING,
     STATE_LOCKED,
-    STATE_UNLOCKED
-    )
+    STATE_UNLOCKED,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfPressure,
+    UnitOfTemperature,
+)
 
 from homeassistant.components.climate.const import (
     FAN_AUTO,
-    # FAN_DIFFUSE,
-    # FAN_FOCUS,
     FAN_HIGH,
     FAN_LOW,
     FAN_MEDIUM,
-    # FAN_MIDDLE,
-    # FAN_OFF,
-    # FAN_ON,
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_FAN_ONLY,
-    HVAC_MODE_HEAT,
-    # HVAC_MODE_HEAT_COOL,
-    HVAC_MODE_OFF
-    )
+    HVACMode,
+)
+from homeassistant.components.sensor import SensorDeviceClass
 
 DOMAIN = "aqara_gateway"
 
@@ -138,18 +114,18 @@ DOMAINS = ['air_quality',
            'switch']
 
 UNITS = {
-    DEVICE_CLASS_BATTERY: PERCENTAGE,
-    DEVICE_CLASS_HUMIDITY: PERCENTAGE,
-    DEVICE_CLASS_ILLUMINANCE: LIGHT_LUX,  # zb light and motion and ble flower - lux
-    DEVICE_CLASS_POWER: POWER_WATT,
-    DEVICE_CLASS_PRESSURE: PRESSURE_HPA,
-    DEVICE_CLASS_TEMPERATURE: TEMP_CELSIUS,
-    DEVICE_CLASS_CO2: CONCENTRATION_PARTS_PER_MILLION,
-    DEVICE_CLASS_PM25: 'µg/m³',
-    DEVICE_CLASS_PM10: 'µg/m³',
-    DEVICE_CLASS_PM1: 'µg/m³',
+    SensorDeviceClass.BATTERY: PERCENTAGE,
+    SensorDeviceClass.HUMIDITY: PERCENTAGE,
+    SensorDeviceClass.ILLUMINANCE: LIGHT_LUX,  # zb light and motion and ble flower - lux
+    SensorDeviceClass.POWER: UnitOfPower.WATT,
+    SensorDeviceClass.PRESSURE: UnitOfPressure.HPA,
+    SensorDeviceClass.TEMPERATURE: UnitOfTemperature.CELSIUS,
+    SensorDeviceClass.CO2: CONCENTRATION_PARTS_PER_MILLION,
+    SensorDeviceClass.PM25: 'µg/m³',
+    SensorDeviceClass.PM10: 'µg/m³',
+    SensorDeviceClass.PM1: 'µg/m³',
     'conductivity': CONDUCTIVITY,
-    'consumption': ENERGY_KILO_WATT_HOUR,
+    'consumption': UnitOfEnergy.KILO_WATT_HOUR,
     'gas density': '% LEL',
     'smoke density': '% obs/ft',
     'moisture': PERCENTAGE,
@@ -192,13 +168,13 @@ CONF_INVERT_STATE = 'invert_state'
 CONF_OCCUPANCY_TIMEOUT = 'occupancy_timeout'
 
 # Climate
-HVAC_MODES = [HVAC_MODE_HEAT, HVAC_MODE_COOL, HVAC_MODE_OFF]
+HVAC_MODES = [HVACMode.HEAT, HVACMode.COOL, HVACMode.OFF]
 FAN_MODES = [FAN_LOW, FAN_MEDIUM, FAN_HIGH, FAN_AUTO]
 
 AC_STATE_HVAC = {
-    HVAC_MODE_OFF: 0x01,
-    HVAC_MODE_HEAT: 0x10,
-    HVAC_MODE_COOL: 0x11
+    HVACMode.OFF: 0x01,
+    HVACMode.HEAT: 0x10,
+    HVACMode.COOL: 0x11
 }
 
 AC_STATE_FAN = {
@@ -209,11 +185,11 @@ AC_STATE_FAN = {
 }
 
 YUBA_STATE_HVAC = {
-    HVAC_MODE_OFF: 0,
-    HVAC_MODE_HEAT: 0,
-    HVAC_MODE_DRY: 3,
-    HVAC_MODE_FAN_ONLY: 4,
-    HVAC_MODE_AUTO: 5
+    HVACMode.OFF: 0,
+    HVACMode.HEAT: 0,
+    HVACMode.DRY: 3,
+    HVACMode.FAN_ONLY: 4,
+    HVACMode.AUTO: 5
 }
 
 YUBA_STATE_FAN = {


### PR DESCRIPTION
Fix warning in HA 2024.1, replaced deprecated constants

https://developers.home-assistant.io/blog/2023/12/19/constant-deprecation

This will increase the minimum HA version requirement to **2022.11**