### PR TITLE
Add missing Lock Events for Aqara Smart Door Lock D200

### DIFF
--- a/custom_components/aqara_gateway/core/lock_data.py
+++ b/custom_components/aqara_gateway/core/lock_data.py
@@ -87,6 +87,9 @@ LOCK_NOTIFICATION = {
     "unlock by bluetooth": {"default": "Unlocked with Bluetooht by user"},
     "unlock by homekit": {"default": "Unlocked with HomeKit by user"},
     "unlock by key": {"default": "Unlocked with key by user"},
+    "unlock by nfc": {"default": "Unlocked with NFC by user"},
+    "unlock by face": {"default": "Unlocked with Face by user"},
+    "unlock by temporary password": {"default": "Unlocked with Temporary Password"},
     "away mode": {
         "default": "Away mode changed",
         "0": "Away-from-home mode is removed",

--- a/custom_components/aqara_gateway/core/utils.py
+++ b/custom_components/aqara_gateway/core/utils.py
@@ -163,6 +163,7 @@ DEVICES = [{
     # on/off
     'lumi.switch.b1lacn02': ["Aqara", "Single Wall Switch D1", "QBKG21LM"],
     'lumi.switch.l1acn1': ["Aqara", "Single Wall Switch H1", "QBKG27LM"],  # @firesunCN
+    'lumi.switch.b1lacn01': ["Aqara", "Single Wall Switch T1", "QBKG17LM"],
     'params': [
         ['4.1.85', 'channel_0', 'switch', 'switch'],  # or neutral_0?
         ['13.1.85', None, 'button', None],
@@ -182,6 +183,7 @@ DEVICES = [{
 }, {
     'lumi.switch.b2lacn02': ["Aqara", "Double Wall Switch D1", "QBKG22LM"],
     'lumi.switch.l2acn1': ["Aqara", "Double Wall Switch H1", "QBKG28LM"],  # @firesunCN
+    'lumi.switch.b2lacn01': ["Aqara", "Double Wall Switch T1", "QBKG18LM"],
     'params': [
         ['4.1.85', 'channel_0', 'channel 1', 'switch'],
         ['4.2.85', 'channel_1', 'channel 2', 'switch'],
@@ -194,6 +196,7 @@ DEVICES = [{
     # triple channel on/off, no neutral wire
     'lumi.switch.l3acn3': ["Aqara", "Triple Wall Switch D1", "QBKG25LM"],
     'lumi.switch.l3acn1': ["Aqara", "Triple Wall Switch H1", "QBKG29LM"],  # @firesunCN
+    'lumi.switch.b3l01': ["Aqara", "Triple Wall Switch T1", "QBKG33LM"],
     'params': [
         ['4.1.85', 'neutral_0', 'channel 1', 'switch'],  # @to4ko
         ['4.2.85', 'neutral_1', 'channel 2', 'switch'],  # @to4ko


### PR DESCRIPTION
Inspired by this commit (niceboygithub/AqaraGateway@1db574d)
Already tested and can successfully retrieve face unlock events, but NFC and temporary password have not been tested yet.