### PR TITLE
Fix mqtt message handler with asyncio

### DIFF
--- a/custom_components/aqara_gateway/core/gateway.py
+++ b/custom_components/aqara_gateway/core/gateway.py
@@ -491,6 +491,9 @@ class Gateway:
         self.hass.create_task(self.async_run())
 
     def on_message(self, client: Client, userdata, msg: MQTTMessage):
+        self.hass.loop.call_soon_threadsafe(self._on_message, msg)
+
+    def _on_message(self, msg: MQTTMessage):
         # pylint: disable=unused-argument
         """ on getting messages from mqtt server """
 


### PR DESCRIPTION
Currently, it will cause error in some cases, in HA 2024.4 beta.  Specifically, is in automation with `xiaomi_aqara.click` event.

I'm not sure if this is a problem on this side, but it can be fixed in this way.