### PR TITLE
Replace deprecated typing alias

### DIFF
--- a/custom_components/aqara_gateway/core/entry_data.py
+++ b/custom_components/aqara_gateway/core/entry_data.py
@@ -1,14 +1,9 @@
 """Runtime entry data for Aqara stored in hass.data."""
-import asyncio
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Optional
 
 import attr
-
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.storage import Store
-from homeassistant.helpers.typing import HomeAssistantType
 
 
 @attr.s
@@ -30,7 +25,7 @@ class RuntimeEntryData:
 
     @callback
     def async_update_entity(
-        self, hass: HomeAssistantType, component_key: str, key: int
+        self, hass: HomeAssistant, component_key: str, key: int
     ) -> None:
         """Schedule the update of an entity."""
         signal = f"aqaragateway_{self.entry_id}_update_{component_key}_{key}"
@@ -38,7 +33,7 @@ class RuntimeEntryData:
 
     @callback
     def async_remove_entity(
-        self, hass: HomeAssistantType, component_key: str, key: int
+        self, hass: HomeAssistant, component_key: str, key: int
     ) -> None:
         """Schedule the removal of an entity."""
         signal = f"aqaragateway_{self.entry_id}_remove_{component_key}_{key}"

--- a/custom_components/aqara_gateway/core/utils.py
+++ b/custom_components/aqara_gateway/core/utils.py
@@ -7,15 +7,14 @@ from datetime import datetime
 from typing import Optional
 
 from aiohttp import web
-from miio import Device, DeviceException
-
 from homeassistant.components import persistent_notification
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.helpers.device_registry import DeviceRegistry
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers.device_registry import DeviceRegistry
+from miio import Device, DeviceException
 
-from .const import DOMAIN, SIGMASTAR_MODELS, AIOT_MODELS
+from .const import AIOT_MODELS, SIGMASTAR_MODELS
 
 SOFT_HACK_REALTEK = {"ssid": "\"\"", "pswd": "123123 ; passwd -d admin ; echo enable > /sys/class/tty/tty/enable; telnetd"}
 SOFT_HACK_SIGMASTAR = {"ssid": "\"\"", "pswd": "123123 ; passwd -d root ; /bin/riu_w 101e 53 3012 ; telnetd"}
@@ -1840,7 +1839,7 @@ class Utils:
         return None
 
     @staticmethod
-    def remove_device(hass: HomeAssistantType, did: str):
+    def remove_device(hass: HomeAssistant, did: str):
         """Remove device by did from Hass"""
         if not isinstance(did, str):
             return
@@ -2026,7 +2025,7 @@ class AqaraGatewayDebug(logging.Handler, HomeAssistantView):
 
     text = ''
 
-    def __init__(self, hass: HomeAssistantType):
+    def __init__(self, hass: HomeAssistant):
         super().__init__()
 
         # random url because without authorization!!!


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2024/04/08/deprecated-backports-and-typing-aliases

Fixed warning in HA 2024.5
