### PR TITLE
Remove KTWKQ01ES

### DIFF
--- a/custom_components/aqara_gateway/core/utils.py
+++ b/custom_components/aqara_gateway/core/utils.py
@@ -817,7 +817,6 @@ DEVICES = [{
 	]
 }, {
     'lumi.airrtc.tcpecn01': ["Aqara", "Thermostat S1", "KTWKQ02ES"],
-    'lumi.ctrl_hvac.es1': ["Aqara", "Thermostat", "KTWKQ01ES"],
     # https://github.com/AlexxIT/XiaomiGateway3/issues/101
     'lumi.airrtc.tcpecn02': ["Aqara", "Thermostat S2", "KTWKQ03ES"],
     'params': [


### PR DESCRIPTION
The devices failed function after recently update. Have updated to S2 so probably it's better to remove the support. Although I do wonder it could flash the firmware to KTWKQ02ES (it's only L/N version different) to fix the issue.