### PR TITLE
import functions used from system_info directly

### DIFF
--- a/custom_components/aqara_gateway/__init__.py
+++ b/custom_components/aqara_gateway/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.helpers.system_info import async_get_system_info
 
 from .core.gateway import Gateway
 from .core.utils import AqaraGatewayDebug
@@ -177,7 +178,7 @@ async def _setup_logger(hass: HomeAssistant):
         handler = AqaraGatewayDebug(hass)
         _LOGGER.addHandler(handler)
 
-        info = await hass.helpers.system_info.async_get_system_info()
+        info = await async_get_system_info(hass)
         info.pop('timezone')
         _LOGGER.debug(f"SysInfo: {info}")
 


### PR DESCRIPTION
Fix the warning

`2024-09-18 10:51:55.319 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'aqara_gateway' accesses hass.helpers.system_info. This is deprecated and will stop working in Home Assistant 2024.11, it should be updated to import functions used from system_info directly at custom_components/aqara_gateway/__init__.py, line 177: info = await hass.helpers.system_info.async_get_system_info(), please create a bug report at https://github.com/niceboygithub/AqaraGateway/issues`