### PR TITLE
fix: fix Motion Sensor E1 model

### DIFF
--- a/custom_components/aqara_gateway/core/utils.py
+++ b/custom_components/aqara_gateway/core/utils.py
@@ -1338,7 +1338,7 @@ DEVICES_AIOT = [{
 }, {
     # motion sensor with illuminance
     'lumi.motion.agl02': ["Aqara", "Motion Sensor T1", "RTCGQ12LM"],  # @miniknife88
-    'lumi.motion.acn001': ["Aqara", "Motion Sensor E1", "RTCGO15LM"],
+    'lumi.motion.acn001': ["Aqara", "Motion Sensor E1", "RTCGQ15LM"],
     'params': [
         ['0.3.85', 'lux', 'illuminance_lux', None],
         ['0.4.85', 'illumination', 'illuminance', 'sensor'],


### PR DESCRIPTION
The model of the motion sensor E1 should be RTCGQ15LM, not RTCGO15LM.

https://www.zigbee2mqtt.io/devices/RTCGQ15LM.html#aqara-rtcgq15lm