### PR TITLE
fix: handle report messages missing 'mi_spec' or data keys

### DIFF
--- a/custom_components/aqara_gateway/core/gateway.py
+++ b/custom_components/aqara_gateway/core/gateway.py
@@ -655,6 +655,9 @@ class Gateway:
             _LOGGER.warning("Unsupported cmd: {}".format(data))
             return
 
+        if pkey == 'mi_spec' and pkey not in data:
+            return
+
         did = data['did']
 
         if did == 'lumi.0':


### PR DESCRIPTION
fix #366 