### PR TITLE
Fix incorrect brightness resource for Ceiling Lamp H1

### DIFF
--- a/custom_components/aqara_gateway/core/utils.py
+++ b/custom_components/aqara_gateway/core/utils.py
@@ -403,7 +403,6 @@ DEVICES = [{
     'params': [
         ['1.10.85', None, 'present_mode', None],
         ['0.12.85', 'load_power', 'power', 'sensor'],
-        ['14.1.85', 'light_level', 'brightness', None],
         ['4.1.85', 'power_status', 'light', 'light'],
         ['1.7.85', 'light_level', 'brightness', None],
         ['1.9.85', 'colour_temperature', 'color_temp', None],


### PR DESCRIPTION
* Resource name on Ceiling Lamp H1 (HCXDD13LM) is 1.7.85, not 14.1.85
* Test passed on HCXDD13LM

## Questions

* Should I split lumi.light.{acn031,acn032} and lumi.light.acn033? I don't have the former for testing.
* But two light_level seems a bug.