### PR TITLE
Fix legacy M1S Telnet device discovery

### DIFF
--- a/custom_components/aqara_gateway/core/shell.py
+++ b/custom_components/aqara_gateway/core/shell.py
@@ -116,26 +116,45 @@ class TelnetShell(Telnet):
         return self.run_command("ps")
 
     def read_file(self, filename: str, as_base64=False, with_newline=True):
-        """ read file content """
+        """Read complete file content from the gateway."""
         # pylint: disable=broad-except
         try:
+            command = "cat {} | base64".format(filename) if as_base64 \
+                else "cat {}".format(filename)
+            raw = self.run_command(command)
+
+            if not raw:
+                raise RuntimeError(
+                    "Gateway returned no data for {}".format(filename)
+                )
+
+            raw = raw.replace("\r\n", "\n").replace("\r", "\n")
+            lines = raw.splitlines()
+            suffix = self._suffix.strip()
+
+            while lines and lines[-1].strip() == suffix:
+                lines.pop()
+
+            if lines and lines[0].strip() == command:
+                lines.pop(0)
+
+            raw = "\n".join(lines).strip()
+
+            if not raw:
+                raise RuntimeError(
+                    "Gateway returned empty file content for {}".format(
+                        filename
+                    )
+                )
+
             if as_base64:
-                command = "cat {} | base64\n".format(filename)
-                self.write(command.encode())
-                raw = self.read_until(self._suffix.encode()).decode()
-                if not with_newline:
-                    raw = self.read_until(self._suffix.encode()).decode()
-                return base64.b64decode(raw)
-            command = "cat {}\n".format(filename)
-            self.write(command.encode())
-            ret = self.read_until(self._suffix.encode()).decode()
-            if not with_newline:
-                ret = self.read_until(self._suffix.encode()).decode()
-            if ret.endswith(self._suffix):
-                ret = "".join(ret.rsplit(self._suffix, 1))
-            return ret.strip("\n")
-        except Exception:
-            return ''
+                return base64.b64decode("".join(raw.splitlines()))
+
+            return raw if with_newline else "".join(raw.splitlines())
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed reading gateway file {}: {}".format(filename, exc)
+            ) from exc
 
     def get_prop(self, property_value: str):
         """ get property """
@@ -177,7 +196,6 @@ class TelnetShell(Telnet):
         return raw[raw.find(">>>") + 4:]
 
     def get_token(self):
-        """ get gateway token """
         filename = "/data/miio/device.token"
         if self.file_exist(filename):
             return self.read_file(filename).rstrip().encode().hex()
@@ -197,7 +215,7 @@ class TelnetShell(Telnet):
             "G2H": "g2h",
             "M2": "m2 2022",
             "M3": "m3",
-            "M1S": "m1s gen2",
+            "M1S": "m1s",
             "V1": "v1",
             "M200": "m200",
             "M100": "m100"
@@ -294,4 +312,3 @@ class TelnetShellM2POE(TelnetShell):
         self.read_until(b"/ # ", timeout=10)
         self.run_command("stty -echo")
         self.read_until(self._suffix.encode(), timeout=10)
-


### PR DESCRIPTION
## Summary

Fix device discovery on legacy or custom-firmware Aqara M1S gateways.

The integration could connect to MQTT successfully, but failed to load devices over Telnet with errors such as:

```text
Can't get devices: Expecting value: line 1 column 1 (char 0)
```

or:

```text
Failed reading gateway file /data/zigbee/coordinator.info:
telnet connection closed
```

## Root cause

There were two related issues:

1. Generic M1S gateways were detected as `m1s gen2` and routed through `TelnetShellM2POE`, which expects a `/ # ` shell prompt.

   Older or custom-firmware M1S gateways use the classic `# ` prompt, so the integration waited for the wrong prompt and the Telnet connection eventually closed.

2. `TelnetShell.read_file()` performed a second `read_until()` whenever `with_newline=False`.

   The first read had already consumed the file contents and shell prompt. The second read therefore returned empty data, timed out, or encountered a closed Telnet connection. The empty result was then passed to `json.loads()`.

## Changes

* Map generic M1S detection to `m1s` instead of `m1s gen2`.
* Route legacy M1S gateways through the standard `TelnetShell`.
* Read file contents from Telnet only once.
* Make `with_newline` affect output formatting instead of triggering another network read.
* Remove echoed commands and trailing shell prompts from file output.
* Preserve useful file-read exceptions instead of silently returning an empty string.

## Tested with

* Home Assistant Container 2026.7.4
* Python 3.14.6
* Aqara M1S
* Custom firmware `4.0.6_0006.0646`
* Zigbee coordinator version `6.46`

After applying the changes:

* `coordinator.info` and `device.info` load successfully
* paired Zigbee devices are discovered
* MQTT heartbeats and state updates continue working
* the previous Telnet and JSON parsing errors no longer appear
